### PR TITLE
Use context CSRF token when using session stored CSRF tokens.

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -11,6 +11,7 @@ from django.contrib.contenttypes.admin import (GenericStackedInline,
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, Http404
+from django.middleware.csrf import get_token
 from django.shortcuts import render, get_object_or_404
 from django.template.defaultfilters import capfirst
 from django.utils.decorators import method_decorator
@@ -192,6 +193,9 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
         except AttributeError:
             verbose_name_plural = opts.verbose_name_plural
 
+        csrf_token = get_token(self.request) if \
+            getattr(settings, 'CSRF_USE_SESSIONS', False) else None
+
         context = self.admin_site.each_context(request)
         context.update({
             'title': u'Drag and drop {0} to change display order'.format(
@@ -204,7 +208,8 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             'sortable_by_class_is_sortable': sortable_by_class_is_sortable,
             'sortable_by_class_display_name': sortable_by_class_display_name,
             'jquery_lib_path': jquery_lib_path,
-            'csrf_cookie_name': getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken')
+            'csrf_cookie_name': getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'),
+            'csrf_token': csrf_token
         })
         return render(request, self.sortable_change_list_template, context)
 

--- a/adminsortable/templates/adminsortable/change_form.html
+++ b/adminsortable/templates/adminsortable/change_form.html
@@ -9,7 +9,7 @@
     {% if has_sortable_tabular_inlines or has_sortable_stacked_inlines %}
         <script type="text/javascript" src="{% static 'adminsortable/js/jquery-ui-django-admin.min.js' %}"></script>
         <script src="{% static 'adminsortable/js/jquery.ui.touch-punch.min.js' %}"></script>
-        {% include 'adminsortable/csrf/jquery.django-csrf.html' with csrf_cookie_name=csrf_cookie_name %}
+        {% include 'adminsortable/csrf/jquery.django-csrf.html' with csrf_cookie_name=csrf_cookie_name csrf_token=csrf_token %}
     {% endif %}
 
     {% if has_sortable_tabular_inlines %}

--- a/adminsortable/templates/adminsortable/change_list.html
+++ b/adminsortable/templates/adminsortable/change_list.html
@@ -27,7 +27,7 @@
 <script src="{% static 'admin/js/jquery.init.js' %}"></script>
 <script src="{% static 'adminsortable/js/jquery-ui-django-admin.min.js' %}"></script>
 <script src="{% static 'adminsortable/js/jquery.ui.touch-punch.min.js' %}"></script>
-{% include 'adminsortable/csrf/jquery.django-csrf.html' with csrf_cookie_name=csrf_cookie_name %}
+{% include 'adminsortable/csrf/jquery.django-csrf.html' with csrf_cookie_name=csrf_cookie_name csrf_token=csrf_token %}
 <script src="{% static 'adminsortable/js/admin.sortable.js' %}"></script>
 {% endblock %}
 

--- a/adminsortable/templates/adminsortable/csrf/jquery.django-csrf.html
+++ b/adminsortable/templates/adminsortable/csrf/jquery.django-csrf.html
@@ -16,7 +16,7 @@
         return cookieValue;
     }
 
-    var csrftoken = getCookie('{{ csrf_cookie_name }}');
+    var csrftoken = '{{ csrf_token }}' || getCookie('{{ csrf_cookie_name }}');
 
     function csrfSafeMethod(method) {
         // these HTTP methods do not require CSRF protection


### PR DESCRIPTION
This solves https://github.com/alsoicode/django-admin-sortable/issues/178

It injects CSRF tokens into the context when `CSRF_USE_SESSIONS =
True` so that the token can be added to request headers.