### PR TITLE
Remove filter_expression which breaks change order

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -116,7 +116,6 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
         """
         # get sort group index from querystring if present
         sort_filter_index = request.GET.get('sort_filter')
-        filter_expression = request.GET.get('filter_expression')
 
         filters = {}
 
@@ -125,11 +124,6 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
                 filters = self.model.sorting_filters[int(sort_filter_index)][1]
             except (IndexError, ValueError):
                 pass
-
-        if filter_expression:
-            filters.update(
-                dict([filter_expression.split('=')])
-            )
 
         # Apply any sort filters to create a subset of sortable objects
         return self.get_queryset(request).filter(**filters)

--- a/adminsortable/templates/adminsortable/change_list.html
+++ b/adminsortable/templates/adminsortable/change_list.html
@@ -29,23 +29,6 @@
 <script src="{% static 'adminsortable/js/jquery.ui.touch-punch.min.js' %}"></script>
 {% include 'adminsortable/csrf/jquery.django-csrf.html' with csrf_cookie_name=csrf_cookie_name %}
 {% include 'adminsortable/admin.sortable.html' with after_sorting_js_callback_name=after_sorting_js_callback_name %}
-
-<script type="text/javascript">
-(function($) {
-    $(document).ready(function($) {
-        var url = window.location.href;
-        var urlParts = url.split('?');
-        var changeListUrl = $('a#return-to-changelist').attr('href');
-
-        if (urlParts.length === 2) {
-            $('a#return-to-changelist').attr(
-                'href',
-                changeListUrl + '?' + urlParts[1].replace('filter_expression=', '')
-            );
-        }
-    });
-})(django.jQuery);
-</script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}

--- a/adminsortable/templates/adminsortable/change_list_with_sort_link.html
+++ b/adminsortable/templates/adminsortable/change_list_with_sort_link.html
@@ -3,18 +3,6 @@
 
 {% block extrahead %}
     {{ block.super }}
-    <script type="text/javascript">
-    (function($) {
-        $(document).ready(function($) {
-            var url = window.location.href;
-            var urlParts = url.split('?');
-
-            if (urlParts.length === 2) {
-                $('a#change-order').attr('href', './sort/?filter_expression=' + urlParts[1]);
-            }
-        });
-    })(django.jQuery);
-    </script>
 {% endblock %}
 
 


### PR DESCRIPTION
When you paginate or sort in the Django admin then select change order, the admin breaks because of the filter_expression code I removed in this PR.  I am running Django version 2.1 and the latest version of django-admin-sortable.