### PR TITLE
Remove deprecated template tag libraries.

### DIFF
--- a/adminsortable/templates/adminsortable/change_form.html
+++ b/adminsortable/templates/adminsortable/change_form.html
@@ -1,6 +1,6 @@
 {% extends change_form_template_extends %}
 {% load i18n admin_modify %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/adminsortable/templates/adminsortable/edit_inline/stacked.html
+++ b/adminsortable/templates/adminsortable/edit_inline/stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static django_template_additions %}
+{% load i18n admin_urls static django_template_additions %}
 {% get_django_version as django_version %}
 <div class="inline-group" id="{{ inline_admin_formset.formset.prefix }}-group">
   <h2>{{ inline_admin_formset.opts.verbose_name_plural|title }} {% if inline_admin_formset.formset.initial_form_count > 1 %} - {% trans "drag and drop to change order" %}{% endif %}</h2>

--- a/adminsortable/templates/adminsortable/edit_inline/tabular.html
+++ b/adminsortable/templates/adminsortable/edit_inline/tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static admin_modify django_template_additions %}{% load cycle from future %}
+{% load i18n admin_urls static admin_modify django_template_additions %}{% load cycle from future %}
 {% get_django_version as django_version %}
 <div class="inline-group {% if django_version.major >= 1 and django_version.minor >= 9 %}flat-admin{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">


### PR DESCRIPTION
Addresses issue #217 

`{% load staticfiles %}` and `{% load adminstatic %}` were
[deprecated in Django 2.1](https://docs.djangoproject.com/en/2.2/releases/2.1/#features-deprecated-in-2-1),
and [removed in Django 3.0](https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0).

Instead, `{% load static %}` should be used.