### PR TITLE
Fixups and improvements

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -313,17 +313,17 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             with transaction.atomic():
 
                 objects_dict = {str(obj.pk): obj for obj in qs}
+                objects_list = list(objects_dict.keys())
                 order_field_name = klass._meta.ordering[0]
 
                 if order_field_name.startswith('-'):
                     order_field_name = order_field_name[1:]
                     step = -1
-                    start_object = max(objects_dict.values(),
-                        key=lambda x: getattr(x, order_field_name))
+                    start_object = objects_dict[objects_list[-1]]
+
                 else:
                     step = 1
-                    start_object = min(objects_dict.values(),
-                        key=lambda x: getattr(x, order_field_name))
+                    start_object = objects_dict[objects_list[0]]
 
                 start_index = getattr(start_object, order_field_name,
                     len(indexes))

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -314,6 +314,15 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
 
                 objects_dict = {str(obj.pk): obj for obj in qs}
                 objects_list = list(objects_dict.keys())
+                if len(indexes) != len(objects_dict):
+                    return HttpResponseBadRequest(
+                        json.dumps({
+                            'objects_sorted': False,
+                            'reason': _("An object has been added or removed "
+                                        "since the last load. Please refresh "
+                                        "the page and try reordering again."),
+                        }, ensure_ascii=False),
+                        content_type='application/json')
                 order_field_name = klass._meta.ordering[0]
 
                 if order_field_name.startswith('-'):

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -15,6 +15,7 @@ from django.http import HttpResponse
 from django.shortcuts import render
 from django.template.defaultfilters import capfirst
 from django.utils.decorators import method_decorator
+from django.utils.six.moves.urllib.parse import urlencode
 from django.views.decorators.http import require_POST
 
 from adminsortable.fields import SortableForeignKey
@@ -236,6 +237,8 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
         else:
             context = self.admin_site.each_context(request)
 
+        filters = urlencode(self.get_querystring_filters(request))
+
         context.update({
             'title': u'Drag and drop {0} to change display order'.format(
                 capfirst(verbose_name_plural)),
@@ -246,6 +249,7 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
             'sortable_by_class': sortable_by_class,
             'sortable_by_class_is_sortable': sortable_by_class_is_sortable,
             'sortable_by_class_display_name': sortable_by_class_display_name,
+            'filters': filters,
             'jquery_lib_path': jquery_lib_path,
             'csrf_cookie_name': getattr(settings, 'CSRF_COOKIE_NAME', 'csrftoken'),
             'csrf_header_name': getattr(settings, 'CSRF_HEADER_NAME', 'X-CSRFToken'),

--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -182,7 +182,9 @@ class SortableAdmin(SortableAdminBase, ModelAdmin):
                     # Django < 1.9
                     sortable_by_fk = field.rel.to
                 sortable_by_field_name = field.name.lower()
-                sortable_by_class_is_sortable = sortable_by_fk.objects.count() >= 2
+                sortable_by_class_is_sortable = \
+                    isinstance(sortable_by_fk, SortableMixin) and \
+                    sortable_by_fk.objects.count() >= 2
 
         if sortable_by_property:
             # backwards compatibility for < 1.1.1, where sortable_by was a

--- a/adminsortable/static/adminsortable/css/admin.sortable.css
+++ b/adminsortable/static/adminsortable/css/admin.sortable.css
@@ -10,8 +10,8 @@
 	margin-left: 1em;
 }
 
-#sortable ul li,
-#sortable ul li a
+#sortable ul.sortable li,
+#sortable ul.sortable li a
 {
     cursor: move;
 }

--- a/adminsortable/templates/adminsortable/shared/object_rep.html
+++ b/adminsortable/templates/adminsortable/shared/object_rep.html
@@ -2,6 +2,6 @@
 
 <form>
     <input name="pk" type="hidden" value="{{ object.pk|unlocalize }}" />
-    <a href="{% url opts|admin_urlname:'do_sorting' object.model_type_id|unlocalize %}" class="admin_sorting_url"><i class="fa fa-{% if forloop.first %}sort-desc{% elif forloop.last %}sort-asc{% else %}sort{% endif %}"></i> {{ object }}</a>
+    <a href="{% url opts|admin_urlname:'do_sorting' object.model_type_id|unlocalize %}{% if filters %}?{{ filters }}{% endif %}" class="admin_sorting_url"><i class="fa fa-{% if forloop.first %}sort-desc{% elif forloop.last %}sort-asc{% else %}sort{% endif %}"></i> {{ object }}</a>
     {% csrf_token %}
 </form>


### PR DESCRIPTION
First off, thank you for your work on this. I have surveyed pretty much every other model ordering package out there, and none of them fit my use case. This one fit my use case almost perfectly:

* drag-and-drop view
* can graft onto pre-existing model
* can use a custom (pre-existing) field for ordering
* sortable-by model that is not itself sortable

This PR contains some fixups for the case where the sortable-by class is not itself sortable.

* 2bb6a67 - if the sortable-by class is not sortable (eg: does not inherit from `SortableMixin`), then `sortable_by_class_is_sortable` should be `False` or else the `object_rep.html` template tries to render `object.model_type_id` for a model that does not have the `model_type_id`
* 247078c - tweak the CSS in `admin.sortable.css` to avoid applying `cursor: move` to unsortable elements
* 00eb3fd - Pass the page filters into the template, and then into the template to construct the `do_sorting` URL. The intent here was to remove the use of `pk__in` in the queryset for `do_sorting_view`, since that may not be very performant with large amounts of objects in the sort list (see a6fb5d0)
* a6fb5d0 - I refactored/rewrote the `do_sorting_view` to make it a bit more bulletproof, use a dictionary comprehension, lock any of the objects that might be updated, update all of the objects in a transaction, and use Django's `bulk_update` to update all of the objects in one database query. Unfortunately I realized that we still have to use `pk__in` in the queryset filter for filtering the full list of objects (as opposed to just a subset), but this work should hopefully make it easier to excise `pk__in` in the future. I did remove a lot of the exception handling, but I think having so much code in a `try:` block and simply swallowing exceptions like that is a code smell. This new code should have fewer places to throw exceptions, so I think it's a worthwhile trade-off.
* 1b700e0 - This uses Python 3.6's ordered dictionaries (and, I think, ordered `.keys()`) to avoid iterating through the entire list of objects to find the one with the highest/lowest `order_field_name` attribute. I don't think the queryset needs an explicit `.order_by()`, since the queryset will be ordered by that field by default.
* 899f92f - I added a check to ensure that no elements were added between the sort page loading and the `do_sorting_view` firing. If the check fails it returns an HTTP  It would be good to display an error message and automatically refresh the page when the `do_sort_view` responds with a non-200 status, but I wanted to get your feedback before implementing it this way, @alsoicode. This is a bit of a kludge, but it's the only way to implement this without a locking mechanism between the sort page loading and the `do_sort_view` request firing, which presents it's own host of problems.