### PR TITLE
Add a few more generated things to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ atlassian-*
 .codeintel
 __pycache__
 .venv/
+.coverage
+.tox/
+htmlcov/
 build
 .vscode/*


### PR DESCRIPTION
Running `tox` generates `.tox/`, `.coverage`, and `htmlcov/`, so I add those to `.gitignore`.