### PR TITLE
Fix saving with specified order value

### DIFF
--- a/adminsortable/models.py
+++ b/adminsortable/models.py
@@ -89,7 +89,7 @@ class SortableMixin(models.Model):
 
     def save(self, *args, **kwargs):
         needs_default = (self._state.adding if VERSION >= (1, 8) else not self.pk)
-        if needs_default:
+        if not getattr(self, self.order_field_name) and needs_default:
             try:
                 current_max = self.__class__.objects.aggregate(
                     models.Max(self.order_field_name))[self.order_field_name + '__max'] or 0

--- a/sample_project/samples/tests.py
+++ b/sample_project/samples/tests.py
@@ -82,6 +82,11 @@ class SortableTestCase(TestCase):
         self.assertTrue(get_is_sortable(Category.objects.all()),
             'Category has more than one record. It should be sortable.')
 
+    def test_doesnt_overwrite_preexisting_order_field_value(self):
+        self.create_category()
+        category = Category.objects.create(title='Category 2', order=5)
+        self.assertEqual(category.order, 5)
+
     def test_save_order_incremented(self):
         category1 = self.create_category()
         self.assertEqual(category1.order, 1, 'Category 1 order should be 1.')


### PR DESCRIPTION
This PR adjusts the conditional for saving a sortable model where the order field has already been specified.

Previously, this would overwrite that value with the maximum order field value + 1 even if the order field value was already specified.

With this PR, this is only done if the object does not yet have a value for the order field.

I also added a test for this case.