### PR TITLE
Better docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,60 @@ admin.site.register(Category, CategoryAdmin)
 
 The `NonSortableParentAdmin` class is necessary to wire up the additional URL patterns and JavaScript that Django Admin Sortable needs to make your models sortable. The child model does not have to be an inline model, it can be wired directly to Django admin and the objects will be grouped by the non-sortable foreign key when sorting.
 
+#### Sortable Many-to-Many Model
+
+It is also possible to make many-to-many relations sortable, but it requires an explicit many-to-many model.
+
+`models.py`:
+```python
+from django.db import models
+from adminsortable.models import SortableMixin
+from adminsortable.fields import SortableForeignKey
+
+class Image(models.Model):
+    ...
+
+class Gallery(models.Model):
+    class Meta:
+        verbose_name_plural = 'Galleries'
+    ...
+    images = models.ManyToManyField(
+        Image,
+        through_fields=('gallery', 'image'),
+        through='GalleryImageRelation',
+        verbose_name=_('Images')
+    )
+
+class GalleryImageRelation(SortableMixin):
+    """Many to many relation that allows users to sort images in galleries"""
+
+    class Meta:
+        ordering = ['image_order']
+
+    gallery = models.ForeignKey(Gallery, verbose_name=_("Gallery"))
+    image = SortableForeignKey(Image, verbose_name=_("Image"))
+    image_order = models.PositiveIntegerField(default=0, editable=False, db_index=True)
+```
+
+`admin.py`:
+```python
+from django.contrib import admin
+from adminsortable.admin import (SortableAdmin, SortableTabularInline)
+from .models import (Image, Gallery, GalleryImageRelation)
+
+class GalleryImageRelationInlineAdmin(SortableTabularInline):
+    model = GalleryImageRelation
+    extra = 1
+
+class GalleryAdmin(NonSortableParentAdmin):
+    inlines = (GalleryImageRelationInlineAdmin,)
+
+admin.site.register(Image, admin.ModelAdmin)
+admin.site.register(Gallery, GalleryAdmin)
+```
+
+Any non-editable space in each rendered inline will let you drag and drop them into order.
+
 
 ### Backwards Compatibility
 If you previously used Django Admin Sortable, **DON'T PANIC** - everything will still work exactly as before ***without any changes to your code***. Going forward, it is recommended that you use the new `SortableMixin` on your models, as pre-2.0 compatibility might not be a permanent thing.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ admin.site.register(Category, SortableAdmin)
 admin.site.register(Project, SortableAdmin)
 ```
 
+#### Sortable Model With Non-Sortable Parent
+
 Sometimes you might have a parent model that is not sortable, but has child models that are. In that case define your models and admin options as such:
 
 ```python

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,6 +3,8 @@ Quickstart
 
 To get started using ``django-admin-sortable`` simply install it using ``pip``::
 
+    .. code-block:: bash
+
     $ pip install django-admin-sortable
 
 Add ``adminsortable`` to your project's ``INSTALLED_APPS`` setting.
@@ -10,6 +12,8 @@ Add ``adminsortable`` to your project's ``INSTALLED_APPS`` setting.
 Ensure ``django.core.context_processors.static`` is in your ``TEMPLATE_CONTEXT_PROCESSORS`` setting.
 
 Define your model, inheriting from ``adminsortable.Sortable``::
+
+    .. code-block:: python
 
     # models.py
     from adminsortable.models import Sortable
@@ -24,6 +28,8 @@ Define your model, inheriting from ``adminsortable.Sortable``::
             return self.title
 
 Wire up your sortable model to Django admin::
+
+    .. code-block:: python
 
     # admin.py
     from adminsortable.admin import SortableAdmin

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -9,4 +9,6 @@ Inlines may be drag-and-dropped into any order directly from the change form.
 
 Unit and functional tests may be found in the ``app/tests.py`` file and run via:
 
+    .. code-block:: bash
+
     $ python manage.py test app

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@ Using Django Admin Sortable
 Models
 ------
 
-To add sorting to a model, your model needs to inherit from ``Sortable`` and have an inner ``Meta`` class that inherits from ``Sortable.Meta``::
+To add sorting to a model, your model needs to inherit from ``SortableMixin`` and at minimum, define an inner ``Meta.ordering`` value
 
     # models.py
     from adminsortable.models import Sortable

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,6 +6,8 @@ Models
 
 To add sorting to a model, your model needs to inherit from ``SortableMixin`` and at minimum, define an inner ``Meta.ordering`` value
 
+    .. code-block:: python
+
     # models.py
     from adminsortable.models import Sortable
 
@@ -22,7 +24,7 @@ It is also possible to order objects relative to another object that is a Foreig
 
 .. note:: A small caveat here is that ``Category`` must also either inherit from ``Sortable`` or include an ``order`` property which is a ``PositiveSmallInteger`` field. This is due to the way Django admin instantiates classes.
 
-::
+    .. code-block:: python
 
     # models.py
     from adminsortable.fields import SortableForeignKey
@@ -53,6 +55,8 @@ If you're adding Sorting to an existing model, it is recommended that you use `d
 
 Example assuming a model named "Category"::
 
+    .. code-block:: python
+
     def forwards(self, orm):
         for index, category in enumerate(orm.Category.objects.all()):
             category.order = index + 1
@@ -65,6 +69,8 @@ Django Admin
 
 To enable sorting in the admin, you need to inherit from ``SortableAdmin``::
 
+    .. code-block:: python
+
         from django.contrib import admin
         from myapp.models import MySortableClass
         from adminsortable.admin import SortableAdmin
@@ -76,6 +82,8 @@ To enable sorting in the admin, you need to inherit from ``SortableAdmin``::
 
 To enable sorting on TabularInline models, you need to inherit from SortableTabularInline::
 
+    .. code-block:: python
+
     from adminsortable.admin import SortableTabularInline
 
     class MySortableTabularInline(SortableTabularInline):
@@ -83,12 +91,16 @@ To enable sorting on TabularInline models, you need to inherit from SortableTabu
 
 To enable sorting on StackedInline models, you need to inherit from SortableStackedInline::
 
+    .. code-block:: python
+
     from adminsortable.admin import SortableStackedInline
 
     class MySortableStackedInline(SortableStackedInline):
         """Your inline options go here"""
 
 There are also generic equivalents that you can inherit from::
+
+    .. code-block:: python
 
     from adminsortable.admin import (SortableGenericTabularInline,
         SortableGenericStackedInline)
@@ -107,6 +119,8 @@ Overriding ``queryset()`` for an inline model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is a special case, which requires a few lines of extra code to properly determine the sortability of your model. Example::
+
+    .. code-block:: python
 
     # add this import to your admin.py
     from adminsortable.utils import get_is_sortable
@@ -136,6 +150,8 @@ Sorting subsets of objects
 It is also possible to sort a subset of objects in your model by adding a ``sorting_filters`` tuple. This works exactly the same as ``.filter()`` on a QuerySet, and is applied *after* ``get_queryset()`` on the admin class, allowing you to override the queryset as you would normally in admin but apply additional filters for sorting. The text "Change Order of" will appear before each filter in the Change List template, and the filter groups are displayed from left to right in the order listed. If no ``sorting_filters`` are specified, the text "Change Order" will be displayed for the link.
 
 An example of sorting subsets would be a "Board of Directors". In this use case, you have a list of "People" objects. Some of these people are on the Board of Directors and some not, and you need to sort them independently::
+
+    .. code-block:: python
 
     class Person(Sortable):
         class Meta(Sortable.Meta):
@@ -169,6 +185,8 @@ By default, adminsortable's change form and change list views inherit from Djang
     change_list_template_extends
 
 These attributes have default values of::
+
+    .. code-block:: python
 
     change_form_template_extends = 'admin/change_form.html'
     change_list_template_extends = 'admin/change_list.html'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     install_requires=['django'],
     license='APL',
     long_description=README,
-    long_description_content_type='text/markdown',
     name='django-admin-sortable',
     packages=find_packages(exclude=['sample_project']),
     url='https://github.com/iambrandontaylor/django-admin-sortable',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 from setuptools import setup, find_packages
 
-try:
-    README = open('README.rst').read()
-except:
-    README = None
+with open('README.rst') as readme_file:
+    README = readme_file.read()
 
 setup(
     author='Brandon Taylor',


### PR DESCRIPTION
This PR improves some of the documentation:

* Updates a part of the usage docs to keep them up-to-date with the current codebase
* Adds RST `code-block` segments where appropriate so syntax highlighting/code coloring works properly
* Removes the `long_descrption_content_type` argument to the `setup()` function in `setup.py`, since it was specifying `text/markdown` but the `long_description` was being read from an RST file - `README.rst`. With this PR, the `setup()` function will read in `README.rst` as the `long_description`, and PyPI will assume that the contents are in RST format and display it correctly on the PyPI project page: https://pypi.org/project/django-admin-sortable.
* Adds usage directions for many-to-many models based on @izhukov1992's [comment](https://github.com/alsoicode/django-admin-sortable/issues/17#issuecomment-292704115) in #17. Please note that I have NOT tested this, and I am not sure what the sort view will do in this case. However, it should help users integrate this into their tabular and stacked admin inlines.

Closes #17.